### PR TITLE
Update README and INSTALL to prefix make install with sudo.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,6 @@
 Simply typing
 
-    make install
+    sudo make install
 
 should install wl-clipboard-x11 to the standard locations.
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Dependencies:
 - [`wl-clipboard`][wl-clipboard]
 
 ```
-$ git clone https://github.com/brunelli/wl-clipboard-x11.git wl-clipboard-x11
+$ git clone https://github.com/brunelli/wl-clipboard-x11.git
 $ cd wl-clipboard-x11
-$ make install
+$ sudo make install
 ```
 
 See [INSTALL][install] for details.


### PR DESCRIPTION
Some minor changes. 
- Specifying the directory to clone to (`wl-clipboard-x11`) is unnecessary since that will be directory by default
- `make install` requires root privileges by default