### PR TITLE
Allow installing only the core script and manpage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,24 +9,32 @@ MANDIR ?= $(PREFIX)/share/man
 all:
 	@echo "$(NAME) is a shell script, so there is nothing to do. Try \"make install\" instead."
 
-install:
+install.core:
 	@install -v -d "$(DESTDIR)$(SHAREDIR)/$(NAME)/"
 	@install -m 0755 -v "$(SRCFILE)" "$(DESTDIR)$(SHAREDIR)/$(NAME)/$(NAME)"
 	@install -v -d "$(DESTDIR)$(MANDIR)/man1"
 	@install -m 0644 -v man/$(NAME).1 "$(DESTDIR)$(MANDIR)/man1/$(NAME).1"
+
+install.links: install.core
 	@ln -nsvf "$(NAME).1" "$(DESTDIR)$(MANDIR)/man1/xclip.1"
 	@ln -nsvf "$(NAME).1" "$(DESTDIR)$(MANDIR)/man1/xsel.1"
 	@install -v -d "$(DESTDIR)$(BINDIR)/"
-	@ln -nsvf "$(DESTDIR)$(SHAREDIR)/$(NAME)/$(NAME)" "$(DESTDIR)$(BINDIR)/xclip"
-	@ln -nsvf "$(DESTDIR)$(SHAREDIR)/$(NAME)/$(NAME)" "$(DESTDIR)$(BINDIR)/xsel"
+	@ln -nsvf "$(SHAREDIR)/$(NAME)/$(NAME)" "$(DESTDIR)$(BINDIR)/xclip"
+	@ln -nsvf "$(SHAREDIR)/$(NAME)/$(NAME)" "$(DESTDIR)$(BINDIR)/xsel"
 
-uninstall:
+install: install.links
+
+uninstall.core:
+	@rm -vf \
+		"$(DESTDIR)$(MANDIR)/man1/$(NAME).1" \
+		"$(DESTDIR)$(SHAREDIR)/$(NAME)/$(NAME)"
+
+uninstall.links: uninstall.core
 	unlink "$(DESTDIR)$(BINDIR)/xclip"
 	unlink "$(DESTDIR)$(BINDIR)/xsel"
 	unlink "$(DESTDIR)$(MANDIR)/man1/xclip.1"
 	unlink "$(DESTDIR)$(MANDIR)/man1/xsel.1"
-	@rm -vf \
-		"$(DESTDIR)$(MANDIR)/man1/$(NAME).1" \
-		"$(DESTDIR)$(SHAREDIR)/$(NAME)/$(NAME)"
+
+uninstall: uninstall.links
 
 .PHONY: install uninstall


### PR DESCRIPTION
The links can be managed through the package manager (see: dpkg alternatives, xbps-alternatives).